### PR TITLE
Fixes all style issues

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,146 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any exec using `mix credo -C <name>`. If no exec name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+      #
+        included: ["lib/", "src/", "web/", "apps/"],
+        excluded: [~r"/_build/", ~r"/deps/"]
+      },
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        {Credo.Check.Consistency.ExceptionNames},
+        {Credo.Check.Consistency.LineEndings},
+        {Credo.Check.Consistency.ParameterPatternMatching},
+        {Credo.Check.Consistency.SpaceAroundOperators},
+        {Credo.Check.Consistency.SpaceInParentheses},
+        {Credo.Check.Consistency.TabsOrSpaces},
+
+        # You can customize the priority of any check
+        # Priority values are: `low, normal, high, higher`
+        #
+        {Credo.Check.Design.AliasUsage, priority: :low},
+
+        # For some checks, you can also set other parameters
+        #
+        # If you don't want the `setup` and `test` macro calls in ExUnit tests
+        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
+        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
+        #
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        #
+        {Credo.Check.Design.TagTODO, exit_status: 0},
+        {Credo.Check.Design.TagFIXME},
+
+        {Credo.Check.Readability.FunctionNames},
+        {Credo.Check.Readability.LargeNumbers},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.ModuleAttributeNames},
+        {Credo.Check.Readability.ModuleDoc},
+        {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
+        {Credo.Check.Readability.ParenthesesInCondition},
+        {Credo.Check.Readability.PredicateFunctionNames},
+        {Credo.Check.Readability.PreferImplicitTry},
+        {Credo.Check.Readability.RedundantBlankLines},
+        {Credo.Check.Readability.StringSigils},
+        {Credo.Check.Readability.TrailingBlankLine},
+        {Credo.Check.Readability.TrailingWhiteSpace},
+        {Credo.Check.Readability.VariableNames},
+        {Credo.Check.Readability.Semicolons},
+        {Credo.Check.Readability.SpaceAfterCommas},
+
+        {Credo.Check.Refactor.DoubleBooleanNegation},
+        {Credo.Check.Refactor.CondStatements},
+        {Credo.Check.Refactor.CyclomaticComplexity},
+        {Credo.Check.Refactor.FunctionArity},
+        {Credo.Check.Refactor.LongQuoteBlocks},
+        {Credo.Check.Refactor.MatchInCondition},
+        {Credo.Check.Refactor.NegatedConditionsInUnless},
+        {Credo.Check.Refactor.NegatedConditionsWithElse},
+        {Credo.Check.Refactor.Nesting},
+        {Credo.Check.Refactor.PipeChainStart},
+        {Credo.Check.Refactor.UnlessWithElse},
+
+        {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck},
+        {Credo.Check.Warning.IExPry},
+        {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Warning.LazyLogging},
+        {Credo.Check.Warning.OperationOnSameValues},
+        {Credo.Check.Warning.OperationWithConstantResult},
+        {Credo.Check.Warning.UnusedEnumOperation},
+        {Credo.Check.Warning.UnusedFileOperation},
+        {Credo.Check.Warning.UnusedKeywordOperation},
+        {Credo.Check.Warning.UnusedListOperation},
+        {Credo.Check.Warning.UnusedPathOperation},
+        {Credo.Check.Warning.UnusedRegexOperation},
+        {Credo.Check.Warning.UnusedStringOperation},
+        {Credo.Check.Warning.UnusedTupleOperation},
+        {Credo.Check.Warning.RaiseInsideRescue},
+
+        # Controversial and experimental checks (opt-in, just remove `, false`)
+        #
+        {Credo.Check.Refactor.ABCSize, false},
+        {Credo.Check.Refactor.AppendSingleItem, false},
+        {Credo.Check.Refactor.VariableRebinding, false},
+        {Credo.Check.Warning.MapGetUnsafePass, false},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+
+        # Deprecated checks (these will be deleted after a grace period)
+        #
+        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Warning.NameRedeclarationByAssignment, false},
+        {Credo.Check.Warning.NameRedeclarationByCase, false},
+        {Credo.Check.Warning.NameRedeclarationByDef, false},
+        {Credo.Check.Warning.NameRedeclarationByFn, false},
+
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,9 @@
 [
-  inputs: [".formatter.exs", "mix.exs", "{config,lib,priv,rel,test}/**/*.{ex,exs}"],
+  inputs: [
+    ".credo.exs",
+    ".formatter.exs",
+    "mix.exs",
+    "{config,lib,priv,rel,test}/**/*.{ex,exs}"
+  ],
   line_length: 80
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: [".formatter.exs", "mix.exs", "{config,lib,priv,rel,test}/**/*.{ex,exs}"],
+  line_length: 80
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - PGPASSWORD=postgres psql -c 'create database docdog_test;' -U postgres
 
 script:
+  - mix credo --strict
   - mix coveralls.travis
 
 deploy:

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,16 +6,14 @@
 use Mix.Config
 
 # General application configuration
-config :docdog,
-  ecto_repos: [Docdog.Repo]
+config :docdog, ecto_repos: [Docdog.Repo]
 
 # Configures the endpoint
 config :docdog, DocdogWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: System.get_env("SECRET_KEY_BASE") || "${SECRET_KEY_BASE}",
   render_errors: [view: DocdogWeb.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: Docdog.PubSub,
-           adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: Docdog.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Configures Elixir's Logger
 config :logger, :console,
@@ -23,25 +21,25 @@ config :logger, :console,
   metadata: [:request_id]
 
 config :phoenix, :template_engines,
-       slim: PhoenixSlime.Engine,
-       slime: PhoenixSlime.Engine
+  slim: PhoenixSlime.Engine,
+  slime: PhoenixSlime.Engine
 
 config :phoenix_slime, :use_slim_extension, true
 
 config :ueberauth, Ueberauth,
-       providers: [
-         github: { Ueberauth.Strategy.Github, [] }
-       ]
+  providers: [
+    github: {Ueberauth.Strategy.Github, []}
+  ]
 
 config :ueberauth, Ueberauth.Strategy.Github.OAuth,
-       client_id: System.get_env("GITHUB_CLIENT_ID") || "${GITHUB_CLIENT_ID}",
-       client_secret: System.get_env("GITHUB_CLIENT_SECRET") || "${GITHUB_CLIENT_SECRET}"
+  client_id: System.get_env("GITHUB_CLIENT_ID") || "${GITHUB_CLIENT_ID}",
+  client_secret:
+    System.get_env("GITHUB_CLIENT_SECRET") || "${GITHUB_CLIENT_SECRET}"
 
 config :mime, :types, %{
-           "text/markdown" => ["md"]
-         }
-
+  "text/markdown" => ["md"]
+}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,8 +11,14 @@ config :docdog, DocdogWeb.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
-                    cd: Path.expand("../assets", __DIR__)]]
+  watchers: [
+    node: [
+      "node_modules/brunch/bin/brunch",
+      "watch",
+      "--stdin",
+      cd: Path.expand("../assets", __DIR__)
+    ]
+  ]
 
 # ## SSL Support
 #
@@ -37,7 +43,7 @@ config :docdog, DocdogWeb.Endpoint,
       ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
       ~r{priv/gettext/.*(po)$},
       ~r{lib/docdog_web/views/.*(ex)$},
-      ~r{lib/docdog_web/templates/.*(eex|slim|slime)$},
+      ~r{lib/docdog_web/templates/.*(eex|slim|slime)$}
     ]
   ]
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -70,4 +70,3 @@ config :docdog, Docdog.Repo,
   database: "",
   ssl: true,
   pool_size: 1
-

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,7 +4,8 @@ use Mix.Config
 # you can enable the server option below.
 config :docdog, DocdogWeb.Endpoint,
   http: [port: 4001],
-  secret_key_base: "+xONLYFORTESTSynmgIFCtSnwLoh7SP1PTPzJJq0Yh4vVDiY3O4+kbhlm+svVwS1",
+  secret_key_base:
+    "+xONLYFORTESTSynmgIFCtSnwLoh7SP1PTPzJJq0Yh4vVDiY3O4+kbhlm+svVwS1",
   server: false
 
 # Print only warnings and errors during test

--- a/lib/docdog/editor/document.ex
+++ b/lib/docdog/editor/document.ex
@@ -7,6 +7,7 @@ defmodule Docdog.Editor.Document do
 
   import Ecto.Changeset
 
+  alias Docdog.Editor
   alias Docdog.Editor.Document
   alias Docdog.Editor.Line
   alias Docdog.Editor.SnippetHelper
@@ -20,8 +21,12 @@ defmodule Docdog.Editor.Document do
     belongs_to(:project, Docdog.Editor.Project)
     belongs_to(:user, Docdog.Accounts.User)
 
-    has_many(:lines, Docdog.Editor.Line,
-      on_replace: :mark_as_invalid, on_delete: :nilify_all)
+    has_many(
+      :lines,
+      Docdog.Editor.Line,
+      on_replace: :mark_as_invalid,
+      on_delete: :nilify_all
+    )
   end
 
   @doc false
@@ -29,14 +34,15 @@ defmodule Docdog.Editor.Document do
     document
     |> cast(attrs, [:name, :original_text, :user_id, :project_id])
     |> validate_required([:name, :original_text, :user_id, :project_id])
-    |> put_assoc(:lines, create_lines(
-      attrs["original_text"], attrs["project_id"])
+    |> put_assoc(
+      :lines,
+      create_lines(attrs["original_text"], attrs["project_id"])
     )
   end
 
   def translated_text(document) do
     document
-    |> Docdog.Editor.get_lines_for_document
+    |> Editor.get_lines_for_document()
     |> Enum.map(fn x -> x.translated_text end)
     |> Enum.join("\n\n")
   end

--- a/lib/docdog/editor/document.ex
+++ b/lib/docdog/editor/document.ex
@@ -20,7 +20,8 @@ defmodule Docdog.Editor.Document do
     belongs_to(:project, Docdog.Editor.Project)
     belongs_to(:user, Docdog.Accounts.User)
 
-    has_many(:lines, Docdog.Editor.Line, on_replace: :mark_as_invalid, on_delete: :nilify_all)
+    has_many(:lines, Docdog.Editor.Line,
+      on_replace: :mark_as_invalid, on_delete: :nilify_all)
   end
 
   @doc false
@@ -28,11 +29,14 @@ defmodule Docdog.Editor.Document do
     document
     |> cast(attrs, [:name, :original_text, :user_id, :project_id])
     |> validate_required([:name, :original_text, :user_id, :project_id])
-    |> put_assoc(:lines, create_lines(attrs["original_text"], attrs["project_id"]))
+    |> put_assoc(:lines, create_lines(
+      attrs["original_text"], attrs["project_id"])
+    )
   end
 
   def translated_text(document) do
-    Docdog.Editor.get_lines_for_document(document)
+    document
+    |> Docdog.Editor.get_lines_for_document
     |> Enum.map(fn x -> x.translated_text end)
     |> Enum.join("\n\n")
   end

--- a/lib/docdog/editor/editor.ex
+++ b/lib/docdog/editor/editor.ex
@@ -13,7 +13,8 @@ defmodule Docdog.Editor do
   alias Docdog.Editor.Queries.DocumentQuery
   alias Docdog.Editor.Queries.LineQuery
 
-  defdelegate authorize(action, user, params), to: Docdog.Editor.Policies.Router
+  defdelegate authorize(action, user, params),
+    to: Docdog.Editor.Policies.Router
 
   @doc """
   Returns the list of projects.
@@ -24,7 +25,7 @@ defmodule Docdog.Editor do
       [%Project{}, ...]
 
   """
-  def list_projects() do
+  def list_projects do
     Project
     |> ProjectQuery.default_scope()
     |> Repo.all()
@@ -73,11 +74,10 @@ defmodule Docdog.Editor do
   def all_members_for_project(project) do
     member_ids = project.members
 
-    from(
+    Repo.all from(
       u in Docdog.Accounts.User,
       where: u.id in ^member_ids
     )
-    |> Repo.all
   end
 
   @doc """

--- a/lib/docdog/editor/editor.ex
+++ b/lib/docdog/editor/editor.ex
@@ -5,6 +5,7 @@ defmodule Docdog.Editor do
 
   import Ecto.Query
 
+  alias Ecto.Changeset
   alias Docdog.Repo
   alias Docdog.Editor.Project
   alias Docdog.Editor.Document
@@ -13,8 +14,7 @@ defmodule Docdog.Editor do
   alias Docdog.Editor.Queries.DocumentQuery
   alias Docdog.Editor.Queries.LineQuery
 
-  defdelegate authorize(action, user, params),
-    to: Docdog.Editor.Policies.Router
+  defdelegate authorize(action, user, params), to: Docdog.Editor.Policies.Router
 
   @doc """
   Returns the list of projects.
@@ -74,9 +74,11 @@ defmodule Docdog.Editor do
   def all_members_for_project(project) do
     member_ids = project.members
 
-    Repo.all from(
-      u in Docdog.Accounts.User,
-      where: u.id in ^member_ids
+    Repo.all(
+      from(
+        u in Docdog.Accounts.User,
+        where: u.id in ^member_ids
+      )
     )
   end
 
@@ -122,7 +124,7 @@ defmodule Docdog.Editor do
     new_members_map = %{members: project.members ++ [new_member.id]}
 
     project
-    |> Ecto.Changeset.change(new_members_map)
+    |> Changeset.change(new_members_map)
     |> Repo.update()
   end
 

--- a/lib/docdog/editor/policies/document_policy.ex
+++ b/lib/docdog/editor/policies/document_policy.ex
@@ -1,4 +1,8 @@
 defmodule Docdog.Editor.Policies.DocumentPolicy do
+  @moduledoc """
+  Defines document policies.
+  """
+
   @behaviour Bodyguard.Policy
 
   alias Docdog.Editor.Project
@@ -26,10 +30,16 @@ defmodule Docdog.Editor.Policies.DocumentPolicy do
   # Project owners can update documents in public projects
   def authorize(:update, %User{id: user_id}, %{
         document: %Document{project_id: project_id},
-        project: %Project{id: project_id, public: true, user_id: project_user_id, members: members}
+        project: %Project{
+          id: project_id,
+          public: true,
+          user_id: project_user_id,
+          members: members
+        }
       }) do
     Enum.member?(members, user_id) || user_id == project_user_id
   end
+
   # Only admin can delete documents from public projects
 
   # Documents in private projects
@@ -56,10 +66,14 @@ defmodule Docdog.Editor.Policies.DocumentPolicy do
   # Project owners can update and delete documents in private projects
   def authorize(action, %User{id: user_id}, %{
         document: %Document{project_id: project_id},
-        project: %Project{id: project_id, public: false, user_id: project_user_id, members: members}
+        project: %Project{
+          id: project_id,
+          public: false,
+          user_id: project_user_id,
+          members: members
+        }
       })
-      when action in [:update, :delete]
-  do
+      when action in [:update, :delete] do
     Enum.member?(members, user_id) || user_id == project_user_id
   end
 

--- a/lib/docdog/editor/policies/line_policy.ex
+++ b/lib/docdog/editor/policies/line_policy.ex
@@ -1,4 +1,8 @@
 defmodule Docdog.Editor.Policies.LinePolicy do
+  @moduledoc """
+  Defines line policies.
+  """
+
   @behaviour Bodyguard.Policy
 
   alias Docdog.Editor.Project

--- a/lib/docdog/editor/policies/project_policy.ex
+++ b/lib/docdog/editor/policies/project_policy.ex
@@ -1,45 +1,76 @@
 defmodule Docdog.Editor.Policies.ProjectPolicy do
+  @moduledoc """
+  Defines project policies.
+  """
+
   @behaviour Bodyguard.Policy
 
   alias Docdog.Editor.Project
   alias Docdog.Accounts.User
 
-  # Admin users can do anything
+  @doc """
+  Admin users can do anything.
+  """
   def authorize(_, %User{admin: true}, _), do: true
 
-  # Regular users can craete projects
+  @doc """
+  Regular users can create projects.
+  """
   def authorize(:create, _, _), do: true
 
-  # Every authorized users instead of project author and members can accept invite to project
-  def authorize(:accept_invite, %User{id: user_id}, %{project: %Project{user_id: project_author_id, members: members}}) do
+  @doc """
+  Every authorized users instead of project author and members
+  can accept invite to project.
+  """
+  def authorize(:accept_invite, %User{id: user_id}, %{
+        project: %Project{user_id: project_author_id, members: members}
+      }) do
     !(Enum.member?(members, user_id) || user_id == project_author_id)
   end
 
   # Public projects
 
-  # Regular users can read public projects
+  @doc """
+  Regular users can read public projects.
+  """
   def authorize(:read, _, %{project: %Project{public: true}}), do: true
 
-  # Project owners can update their own public projects
-  def authorize(:update, %User{id: user_id}, %{project: %Project{user_id: user_id, public: true}}),
-    do: true
+  @doc """
+  Project owners can update their own public projects.
+  """
+  def authorize(:update, %User{id: user_id}, %{
+        project: %Project{user_id: user_id, public: true}
+      }),
+      do: true
 
   # Only admin can delete public projects
 
   # Private projects
 
-  # Only project members can read private projects
+  @doc """
+  Only project members can read private projects.
+  """
   def authorize(:read, %User{id: user_id}, %{
-        project: %Project{public: false, user_id: project_user_id, members: members}
+        project: %Project{
+          public: false,
+          user_id: project_user_id,
+          members: members
+        }
       }) do
     Enum.member?(members, user_id) || user_id == project_user_id
   end
 
-  # Project owners can update and delete their own private projects
-  def authorize(action, %User{id: user_id}, %{project: %Project{user_id: user_id, public: false}})
+  @doc """
+  Project owners can update and delete their own private projects.
+  """
+  def authorize(action, %User{id: user_id}, %{
+        project: %Project{user_id: user_id, public: false}
+      })
       when action in [:update, :delete],
       do: true
 
-  # Deny everything else
+  @doc """
+  Deny everything else.
+  """
   def authorize(_, _, _), do: false
 end

--- a/lib/docdog/editor/queries/document_query.ex
+++ b/lib/docdog/editor/queries/document_query.ex
@@ -1,4 +1,8 @@
 defmodule Docdog.Editor.Queries.DocumentQuery do
+  @moduledoc """
+  Defines document queries.
+  """
+
   import Ecto.Query, warn: false
 
   def default_scope(query) do

--- a/lib/docdog/editor/queries/line_query.ex
+++ b/lib/docdog/editor/queries/line_query.ex
@@ -1,4 +1,8 @@
 defmodule Docdog.Editor.Queries.LineQuery do
+  @moduledoc """
+  Defines line queries.
+  """
+
   import Ecto.Query, warn: false
 
   def default_scope(query) do

--- a/lib/docdog/editor/queries/project_query.ex
+++ b/lib/docdog/editor/queries/project_query.ex
@@ -1,4 +1,8 @@
 defmodule Docdog.Editor.Queries.ProjectQuery do
+  @moduledoc """
+  Defines project queries.
+  """
+
   import Ecto.Query, warn: false
 
   alias Docdog.Editor.Project
@@ -34,7 +38,8 @@ defmodule Docdog.Editor.Queries.ProjectQuery do
         p in Project,
         select: %{
           id: p.id,
-          completed_percentage: fragment("count(l2.translated_text) * 100.0 / count(p0.id)")
+          completed_percentage:
+            fragment("count(l2.translated_text) * 100.0 / count(p0.id)")
         },
         left_join: d in assoc(p, :documents),
         left_join: l in assoc(d, :lines),
@@ -46,7 +51,8 @@ defmodule Docdog.Editor.Queries.ProjectQuery do
         s in subquery(documents_subquery),
         select: %{
           id: s.id,
-          completed_percentage: fragment("round(sum(s0.completed_percentage) / count(*), 2)")
+          completed_percentage:
+            fragment("round(sum(s0.completed_percentage) / count(*), 2)")
         },
         group_by: s.id
       )

--- a/lib/docdog/editor/snippet_helper.ex
+++ b/lib/docdog/editor/snippet_helper.ex
@@ -4,8 +4,12 @@ defmodule Docdog.Editor.SnippetHelper do
   """
 
   def process_snippets(text) do
-    snippets = Regex.scan(~r/```[^`]*```/, text) |> Enum.map(&hd/1)
-    replacements = snippets |> Enum.map(&encode_newlines/1)
+    snippets =
+      ~r/```[^`]*```/
+      |> Regex.scan(text)
+      |> Enum.map(&hd/1)
+
+    replacements = Enum.map(snippets, &encode_newlines/1)
 
     snippets
     |> Stream.zip(replacements)

--- a/lib/docdog_web.ex
+++ b/lib/docdog_web.ex
@@ -48,7 +48,11 @@ defmodule DocdogWeb do
       end
 
       def sign_in_with_github_link(conn) do
-        link "Sign in with Github", to: auth_path(conn, :request, :github), class: "btn btn-lg btn-default"
+        link(
+          "Sign in with Github",
+          to: auth_path(conn, :request, :github),
+          class: "btn btn-lg btn-default"
+        )
       end
     end
   end

--- a/lib/docdog_web/controllers/auth_controller.ex
+++ b/lib/docdog_web/controllers/auth_controller.ex
@@ -41,11 +41,11 @@ defmodule DocdogWeb.AuthController do
   end
 
   # We mustn't redirect to auth url
-  defp success_redirect_url(conn, redirect_url = "/auth" <> _) do
+  defp success_redirect_url(conn, "/auth" <> _ = redirect_url) do
     popular_path(conn, :index)
   end
 
-  defp success_redirect_url(_, redirect_url = "/" <> _) do
+  defp success_redirect_url(_, "/" <> _ = redirect_url) do
     redirect_url
   end
 

--- a/lib/docdog_web/controllers/document_controller.ex
+++ b/lib/docdog_web/controllers/document_controller.ex
@@ -1,7 +1,7 @@
 defmodule DocdogWeb.DocumentController do
   use DocdogWeb, :controller
 
-  plug DocdogWeb.AuthorizationRequiredPlug
+  plug(DocdogWeb.AuthorizationRequiredPlug)
 
   alias Docdog.Editor
   alias Docdog.Editor.Document
@@ -11,7 +11,13 @@ defmodule DocdogWeb.DocumentController do
     project = Editor.get_project!(project_id)
     documents = project.documents
 
-    with :ok <- Bodyguard.permit(Editor, :project_read, user, project: project) do
+    with :ok <-
+      Bodyguard.permit(
+        Editor,
+        :project_read,
+        user,
+        project: project
+    ) do
       render(conn, "index.html", project_id: project_id, documents: documents)
     end
   end
@@ -21,9 +27,13 @@ defmodule DocdogWeb.DocumentController do
     project = Editor.get_project!(project_id)
     changeset = Editor.change_document(%Document{})
 
-    with :ok <- Bodyguard.permit(
-        Editor, :document_create, user, project: project
-    ) do
+    with :ok <-
+           Bodyguard.permit(
+             Editor,
+             :document_create,
+             user,
+             project: project
+           ) do
       render(conn, "new.html", project_id: project_id, changeset: changeset)
     end
   end
@@ -32,11 +42,19 @@ defmodule DocdogWeb.DocumentController do
     user = conn.assigns.current_user
     project = Editor.get_project!(project_id)
 
-    with :ok <- Bodyguard.permit(
-        Editor, :document_create, user, project: project
-      ), {:ok, document} <- Editor.create_document(
-        project, user, document_params
-    ) do
+    with :ok <-
+           Bodyguard.permit(
+             Editor,
+             :document_create,
+             user,
+             project: project
+           ),
+         {:ok, document} <-
+           Editor.create_document(
+             project,
+             user,
+             document_params
+           ) do
       conn
       |> put_flash(:info, "Document created successfully.")
       |> redirect(to: project_document_path(conn, :edit, project, document))

--- a/lib/docdog_web/controllers/document_controller.ex
+++ b/lib/docdog_web/controllers/document_controller.ex
@@ -21,7 +21,9 @@ defmodule DocdogWeb.DocumentController do
     project = Editor.get_project!(project_id)
     changeset = Editor.change_document(%Document{})
 
-    with :ok <- Bodyguard.permit(Editor, :document_create, user, project: project) do
+    with :ok <- Bodyguard.permit(
+        Editor, :document_create, user, project: project
+    ) do
       render(conn, "new.html", project_id: project_id, changeset: changeset)
     end
   end
@@ -30,8 +32,11 @@ defmodule DocdogWeb.DocumentController do
     user = conn.assigns.current_user
     project = Editor.get_project!(project_id)
 
-    with :ok <- Bodyguard.permit(Editor, :document_create, user, project: project),
-         {:ok, document} <- Editor.create_document(project, user, document_params) do
+    with :ok <- Bodyguard.permit(
+        Editor, :document_create, user, project: project
+      ), {:ok, document} <- Editor.create_document(
+        project, user, document_params
+    ) do
       conn
       |> put_flash(:info, "Document created successfully.")
       |> redirect(to: project_document_path(conn, :edit, project, document))

--- a/lib/docdog_web/controllers/line_controller.ex
+++ b/lib/docdog_web/controllers/line_controller.ex
@@ -28,7 +28,9 @@ defmodule DocdogWeb.LineController do
     user = get_session(conn, :current_user) || conn.assigns.current_user
     line = Editor.get_line!(id)
 
-    with :ok <- Bodyguard.permit(Editor, :line_update, user, line: line, project: line.project),
+    with :ok <- Bodyguard.permit(
+        Editor, :line_update, user, line: line, project: line.project
+      ),
          {:ok, updated_line} <- Editor.update_line(line, user, line_params) do
       conn
       |> put_status(:ok)

--- a/lib/docdog_web/controllers/line_controller.ex
+++ b/lib/docdog_web/controllers/line_controller.ex
@@ -1,7 +1,7 @@
 defmodule DocdogWeb.LineController do
   use DocdogWeb, :controller
 
-  plug DocdogWeb.AuthorizationRequiredPlug
+  plug(DocdogWeb.AuthorizationRequiredPlug)
 
   alias Docdog.Editor
 
@@ -28,9 +28,14 @@ defmodule DocdogWeb.LineController do
     user = get_session(conn, :current_user) || conn.assigns.current_user
     line = Editor.get_line!(id)
 
-    with :ok <- Bodyguard.permit(
-        Editor, :line_update, user, line: line, project: line.project
-      ),
+    with :ok <-
+           Bodyguard.permit(
+             Editor,
+             :line_update,
+             user,
+             line: line,
+             project: line.project
+           ),
          {:ok, updated_line} <- Editor.update_line(line, user, line_params) do
       conn
       |> put_status(:ok)

--- a/lib/docdog_web/controllers/popular_controller.ex
+++ b/lib/docdog_web/controllers/popular_controller.ex
@@ -1,7 +1,7 @@
 defmodule DocdogWeb.PopularController do
   use DocdogWeb, :controller
 
-  plug DocdogWeb.AuthorizationRequiredPlug
+  plug(DocdogWeb.AuthorizationRequiredPlug)
 
   alias Docdog.Editor
   alias Docdog.Editor.Project

--- a/lib/docdog_web/controllers/project_controller.ex
+++ b/lib/docdog_web/controllers/project_controller.ex
@@ -1,7 +1,7 @@
 defmodule DocdogWeb.ProjectController do
   use DocdogWeb, :controller
 
-  plug DocdogWeb.AuthorizationRequiredPlug
+  plug(DocdogWeb.AuthorizationRequiredPlug)
 
   alias Docdog.Editor
   alias Docdog.Editor.Project
@@ -42,8 +42,15 @@ defmodule DocdogWeb.ProjectController do
     members = Editor.all_members_for_project(project)
     changeset = Editor.change_project(project)
 
-    with :ok <- Bodyguard.permit(Editor, :project_update, user, project: project) do
-      render(conn, "edit.html", project: project, members: members, changeset: changeset)
+    with :ok <-
+           Bodyguard.permit(Editor, :project_update, user, project: project) do
+      render(
+        conn,
+        "edit.html",
+        project: project,
+        members: members,
+        changeset: changeset
+      )
     end
   end
 
@@ -52,14 +59,21 @@ defmodule DocdogWeb.ProjectController do
     project = Editor.get_project!(id)
     members = Editor.all_members_for_project(project)
 
-    with :ok <- Bodyguard.permit(Editor, :project_update, user, project: project),
+    with :ok <-
+           Bodyguard.permit(Editor, :project_update, user, project: project),
          {:ok, _project} <- Editor.update_project(project, project_params) do
       conn
       |> put_flash(:info, "Project updated successfully.")
       |> redirect(to: project_path(conn, :index))
     else
       {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, "edit.html", project: project, members: members, changeset: changeset)
+        render(
+          conn,
+          "edit.html",
+          project: project,
+          members: members,
+          changeset: changeset
+        )
 
       error ->
         error
@@ -70,7 +84,8 @@ defmodule DocdogWeb.ProjectController do
     user = conn.assigns.current_user
     project = Editor.get_project!(id)
 
-    with :ok <- Bodyguard.permit(Editor, :project_delete, user, project: project),
+    with :ok <-
+           Bodyguard.permit(Editor, :project_delete, user, project: project),
          {:ok, _project} <- Editor.delete_project(project) do
       conn
       |> put_flash(:info, "Project deleted successfully.")

--- a/lib/docdog_web/controllers/project_invite_controller.ex
+++ b/lib/docdog_web/controllers/project_invite_controller.ex
@@ -1,7 +1,7 @@
 defmodule DocdogWeb.ProjectInviteController do
   use DocdogWeb, :controller
 
-  plug DocdogWeb.AuthorizationRequiredPlug
+  plug(DocdogWeb.AuthorizationRequiredPlug)
 
   alias Docdog.Editor
   alias Docdog.Editor.Project
@@ -16,9 +16,13 @@ defmodule DocdogWeb.ProjectInviteController do
     user = conn.assigns.current_user
     project = Editor.get_project_by_invite_code!(invite_code)
 
-    with :ok <- Bodyguard.permit(
-        Editor, :project_accept_invite, user, project: project
-      ),
+    with :ok <-
+           Bodyguard.permit(
+             Editor,
+             :project_accept_invite,
+             user,
+             project: project
+           ),
          {:ok, _project} <- Editor.add_member_to_project(project, user) do
       conn
       |> put_flash(:info, "You successfully became a project member.")

--- a/lib/docdog_web/controllers/project_invite_controller.ex
+++ b/lib/docdog_web/controllers/project_invite_controller.ex
@@ -16,7 +16,9 @@ defmodule DocdogWeb.ProjectInviteController do
     user = conn.assigns.current_user
     project = Editor.get_project_by_invite_code!(invite_code)
 
-    with :ok <- Bodyguard.permit(Editor, :project_accept_invite, user, project: project),
+    with :ok <- Bodyguard.permit(
+        Editor, :project_accept_invite, user, project: project
+      ),
          {:ok, _project} <- Editor.add_member_to_project(project, user) do
       conn
       |> put_flash(:info, "You successfully became a project member.")

--- a/lib/docdog_web/endpoint.ex
+++ b/lib/docdog_web/endpoint.ex
@@ -56,7 +56,10 @@ defmodule DocdogWeb.Endpoint do
   """
   def init(_key, config) do
     if config[:load_from_system_env] do
-      port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
+      port =
+        System.get_env("PORT") ||
+          raise "expected the PORT environment variable to be set"
+
       {:ok, Keyword.put(config, :http, [:inet6, port: port])}
     else
       {:ok, config}

--- a/lib/docdog_web/plugs/authorization_required_plug.ex
+++ b/lib/docdog_web/plugs/authorization_required_plug.ex
@@ -18,6 +18,7 @@ defmodule DocdogWeb.AuthorizationRequiredPlug do
         |> put_session(:redirect_url, conn.request_path)
         |> put_flash(:info, "Please, sign in to continue.")
         |> redirect(to: auth_path(conn, :new))
+
       _ ->
         conn
     end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,12 @@ defmodule Docdog.Mixfile do
   def application do
     [
       mod: {Docdog.Application, []},
-      extra_applications: [:ex_machina, :logger, :runtime_tools, :ueberauth_github]
+      extra_applications: [
+        :ex_machina,
+        :logger,
+        :runtime_tools,
+        :ueberauth_github
+      ]
     ]
   end
 
@@ -40,7 +45,6 @@ defmodule Docdog.Mixfile do
       {:phoenix_ecto, "~> 3.2"},
       {:phoenix_html, "~> 2.10"},
       {:phoenix_slime, git: "https://github.com/slime-lang/phoenix_slime"},
-
       {:postgrex, ">= 0.0.0"},
       {:gettext, "~> 0.11"},
       {:ueberauth_github, "~> 0.4"},

--- a/mix.exs
+++ b/mix.exs
@@ -38,19 +38,22 @@ defmodule Docdog.Mixfile do
       {:phoenix, "~> 1.3.0"},
       {:phoenix_pubsub, "~> 1.0"},
       {:phoenix_ecto, "~> 3.2"},
-      {:postgrex, ">= 0.0.0"},
       {:phoenix_html, "~> 2.10"},
-      {:gettext, "~> 0.11"},
       {:phoenix_slime, git: "https://github.com/slime-lang/phoenix_slime"},
+
+      {:postgrex, ">= 0.0.0"},
+      {:gettext, "~> 0.11"},
       {:ueberauth_github, "~> 0.4"},
       {:cowboy, "~> 1.0"},
       {:distillery, "~> 1.0.0"},
       {:bodyguard, "~> 2.2"},
+      {:ex_machina, "~> 2.1"},
+
+      # Development and testing:
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
-      {:excoveralls, "~> 0.8", only: :test},
-      {:ex_machina, "~> 2.1"},
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
+      {:excoveralls, "~> 0.8", only: :test}
     ]
   end
 

--- a/priv/repo/migrations/20170902175906_create_users.exs
+++ b/priv/repo/migrations/20170902175906_create_users.exs
@@ -3,10 +3,9 @@ defmodule Docdog.Repo.Migrations.CreateUsers do
 
   def change do
     create table(:users) do
-      add :username, :string
+      add(:username, :string)
 
       timestamps()
     end
-
   end
 end

--- a/priv/repo/migrations/20170902195651_create_projects.exs
+++ b/priv/repo/migrations/20170902195651_create_projects.exs
@@ -3,12 +3,12 @@ defmodule Docdog.Repo.Migrations.CreateProjects do
 
   def change do
     create table(:projects) do
-      add :name, :string
-      add :user_id, references(:users, on_delete: :nothing)
+      add(:name, :string)
+      add(:user_id, references(:users, on_delete: :nothing))
 
       timestamps()
     end
 
-    create index(:projects, [:user_id])
+    create(index(:projects, [:user_id]))
   end
 end

--- a/priv/repo/migrations/20170902224017_create_documents.exs
+++ b/priv/repo/migrations/20170902224017_create_documents.exs
@@ -3,13 +3,13 @@ defmodule Docdog.Repo.Migrations.CreateDocuments do
 
   def change do
     create table(:documents) do
-      add :name, :string
-      add :original_text, :text
-      add :project_id, references(:projects, on_delete: :nothing)
+      add(:name, :string)
+      add(:original_text, :text)
+      add(:project_id, references(:projects, on_delete: :nothing))
 
       timestamps()
     end
 
-    create index(:documents, [:project_id])
+    create(index(:documents, [:project_id]))
   end
 end

--- a/priv/repo/migrations/20170903111544_create_lines.exs
+++ b/priv/repo/migrations/20170903111544_create_lines.exs
@@ -3,14 +3,14 @@ defmodule Docdog.Repo.Migrations.CreateLines do
 
   def change do
     create table(:lines) do
-      add :original_text, :text
-      add :translated_text, :text
-      add :document_id, references(:documents, on_delete: :nothing)
-      add :index_number, :integer
+      add(:original_text, :text)
+      add(:translated_text, :text)
+      add(:document_id, references(:documents, on_delete: :nothing))
+      add(:index_number, :integer)
 
       timestamps()
     end
 
-    create index(:lines, [:document_id])
+    create(index(:lines, [:document_id]))
   end
 end

--- a/priv/repo/migrations/20170917223650_add_fields_to_users.exs
+++ b/priv/repo/migrations/20170917223650_add_fields_to_users.exs
@@ -3,10 +3,10 @@ defmodule Docdog.Repo.Migrations.AddFieldsToUsers do
 
   def change do
     alter table(:users) do
-      add :email, :string
-      add :avatar, :string
+      add(:email, :string)
+      add(:avatar, :string)
     end
 
-    create index(:users, [:email], unique: true)
+    create(index(:users, [:email], unique: true))
   end
 end

--- a/priv/repo/migrations/20170918123801_add_user_id_to_documents.exs
+++ b/priv/repo/migrations/20170918123801_add_user_id_to_documents.exs
@@ -3,9 +3,9 @@ defmodule Docdog.Repo.Migrations.AddUserIdToDocuments do
 
   def change do
     alter table(:documents) do
-      add :user_id, references(:users, on_delete: :nothing)
+      add(:user_id, references(:users, on_delete: :nothing))
     end
 
-    create index(:documents, [:user_id])
+    create(index(:documents, [:user_id]))
   end
 end

--- a/priv/repo/migrations/20170918123806_add_user_id_to_lines.exs
+++ b/priv/repo/migrations/20170918123806_add_user_id_to_lines.exs
@@ -3,9 +3,9 @@ defmodule Docdog.Repo.Migrations.AddUserIdToLines do
 
   def change do
     alter table(:lines) do
-      add :user_id, references(:users, on_delete: :nothing)
+      add(:user_id, references(:users, on_delete: :nothing))
     end
 
-    create index(:lines, [:user_id])
+    create(index(:lines, [:user_id]))
   end
 end

--- a/priv/repo/migrations/20171213193854_add_processed_to_lines.exs
+++ b/priv/repo/migrations/20171213193854_add_processed_to_lines.exs
@@ -3,9 +3,9 @@ defmodule Docdog.Repo.Migrations.AddProcessedToLines do
 
   def change do
     alter table(:lines) do
-      add :processed, :boolean, default: false, null: false
+      add(:processed, :boolean, default: false, null: false)
     end
 
-    create index(:lines, [:processed])
+    create(index(:lines, [:processed]))
   end
 end

--- a/priv/repo/migrations/20180216180205_change_on_delete_for_document_id_in_lines.exs
+++ b/priv/repo/migrations/20180216180205_change_on_delete_for_document_id_in_lines.exs
@@ -2,16 +2,18 @@ defmodule Docdog.Repo.Migrations.ChangeOnDeleteForDocumentIdInLines do
   use Ecto.Migration
 
   def up do
-    drop constraint(:lines, "lines_document_id_fkey")
+    drop(constraint(:lines, "lines_document_id_fkey"))
+
     alter table(:lines) do
-      modify :document_id, references(:documents, on_delete: :delete_all)
+      modify(:document_id, references(:documents, on_delete: :delete_all))
     end
   end
 
   def down do
-    drop constraint(:lines, "lines_document_id_fkey")
+    drop(constraint(:lines, "lines_document_id_fkey"))
+
     alter table(:lines) do
-      modify :document_id, references(:documents, on_delete: :nothing)
+      modify(:document_id, references(:documents, on_delete: :nothing))
     end
   end
 end

--- a/priv/repo/migrations/20180303205824_add_public_to_projects.exs
+++ b/priv/repo/migrations/20180303205824_add_public_to_projects.exs
@@ -3,9 +3,9 @@ defmodule Docdog.Repo.Migrations.AddPublicToProjects do
 
   def change do
     alter table(:projects) do
-      add :public, :boolean, default: false, null: false
+      add(:public, :boolean, default: false, null: false)
     end
 
-    create index(:projects, [:public])
+    create(index(:projects, [:public]))
   end
 end

--- a/priv/repo/migrations/20180309212108_add_admin_to_users.exs
+++ b/priv/repo/migrations/20180309212108_add_admin_to_users.exs
@@ -3,9 +3,9 @@ defmodule Docdog.Repo.Migrations.AddAdminToUsers do
 
   def change do
     alter table(:users) do
-      add :admin, :boolean, default: false, null: false
+      add(:admin, :boolean, default: false, null: false)
     end
 
-    create index(:users, [:admin])
+    create(index(:users, [:admin]))
   end
 end

--- a/priv/repo/migrations/20180309212149_add_members_to_projects.exs
+++ b/priv/repo/migrations/20180309212149_add_members_to_projects.exs
@@ -3,9 +3,9 @@ defmodule Docdog.Repo.Migrations.AddMembersToProjects do
 
   def change do
     alter table(:projects) do
-      add :members, {:array, :integer}, default: [], null: false
+      add(:members, {:array, :integer}, default: [], null: false)
     end
 
-    create index(:projects, [:members], using: "GIN")
+    create(index(:projects, [:members], using: "GIN"))
   end
 end

--- a/priv/repo/migrations/20180309212527_add_project_id_to_lines.exs
+++ b/priv/repo/migrations/20180309212527_add_project_id_to_lines.exs
@@ -3,9 +3,9 @@ defmodule Docdog.Repo.Migrations.AddProjectIdToLines do
 
   def change do
     alter table(:lines) do
-      add :project_id, references(:projects, on_delete: :nothing)
+      add(:project_id, references(:projects, on_delete: :nothing))
     end
 
-    create index(:lines, [:project_id])
+    create(index(:lines, [:project_id]))
   end
 end

--- a/priv/repo/migrations/20180318174701_add_uuid_extension.exs
+++ b/priv/repo/migrations/20180318174701_add_uuid_extension.exs
@@ -2,10 +2,10 @@ defmodule Docdog.Repo.Migrations.AddUuidExtension do
   use Ecto.Migration
 
   def up do
-    execute "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;"
+    execute("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA public;")
   end
 
   def down do
-    execute "DROP EXTENSION \"uuid-ossp\";"
+    execute("DROP EXTENSION \"uuid-ossp\";")
   end
 end

--- a/priv/repo/migrations/20180318183309_add_invite_code_to_projects.exs
+++ b/priv/repo/migrations/20180318183309_add_invite_code_to_projects.exs
@@ -3,9 +3,14 @@ defmodule Docdog.Repo.Migrations.AddInviteCodeToProjects do
 
   def change do
     alter table(:projects) do
-      add :invite_code, :uuid, null: false, default: fragment("uuid_generate_v4()")
+      add(
+        :invite_code,
+        :uuid,
+        null: false,
+        default: fragment("uuid_generate_v4()")
+      )
     end
 
-    create index(:projects, [:invite_code], unique: true)
+    create(index(:projects, [:invite_code], unique: true))
   end
 end

--- a/priv/repo/migrations/20180405135232_add_github_uid_to_users.exs
+++ b/priv/repo/migrations/20180405135232_add_github_uid_to_users.exs
@@ -3,9 +3,9 @@ defmodule Docdog.Repo.Migrations.AddGithubUidToUsers do
 
   def change do
     alter table(:users) do
-      add :github_uid, :string
+      add(:github_uid, :string)
     end
 
-    create index(:users, [:github_uid], unique: true)
+    create(index(:users, [:github_uid], unique: true))
   end
 end

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -1,12 +1,11 @@
 use Mix.Releases.Config,
-    # This sets the default release built by `mix release`
-    default_release: :default,
-    # This sets the default environment used by `mix release`
-    default_environment: :dev
+  # This sets the default release built by `mix release`
+  default_release: :default,
+  # This sets the default environment used by `mix release`
+  default_environment: :dev
 
 # For a full list of config options for both releases
 # and environments, visit https://hexdocs.pm/distillery/configuration.html
-
 
 # You may define one or more environments in this file,
 # an environment's settings will override those of a release
@@ -14,15 +13,25 @@ use Mix.Releases.Config,
 # and environment configuration is called a profile
 
 environment :dev do
-  set dev_mode: true
-  set include_erts: false
-  set cookie: ("DOCDOG_COOKIE" |> System.get_env() || "${DOCDOG_COOKIE}") |> String.to_atom()
+  set(dev_mode: true)
+  set(include_erts: false)
+
+  set(
+    cookie:
+      ("DOCDOG_COOKIE" |> System.get_env() || "${DOCDOG_COOKIE}")
+      |> String.to_atom()
+  )
 end
 
 environment :prod do
-  set include_erts: true
-  set include_src: false
-  set cookie: ("DOCDOG_COOKIE" |> System.get_env() || "${DOCDOG_COOKIE}") |> String.to_atom()
+  set(include_erts: true)
+  set(include_src: false)
+
+  set(
+    cookie:
+      ("DOCDOG_COOKIE" |> System.get_env() || "${DOCDOG_COOKIE}")
+      |> String.to_atom()
+  )
 end
 
 # You may define one or more releases in this file.
@@ -31,6 +40,5 @@ end
 # will be used by default
 
 release :docdog do
-  set version: current_version(:docdog)
+  set(version: current_version(:docdog))
 end
-

--- a/test/docdog/accounts/accounts_test.exs
+++ b/test/docdog/accounts/accounts_test.exs
@@ -19,7 +19,7 @@ defmodule Docdog.AccountsTest do
       first_name: "Petr",
       last_name: "Petrov",
       image: "",
-      github_uid: 1234567
+      github_uid: 1_234_567
     }
 
     setup do
@@ -51,8 +51,12 @@ defmodule Docdog.AccountsTest do
       assert user.username == "alex_alexandrov"
     end
 
-    test "update_user/2 with invalid data returns error changeset", %{user: user} do
-      assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
+    test "update_user/2 with invalid data returns error changeset", %{
+      user: user
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               Accounts.update_user(user, @invalid_attrs)
+
       assert user == Accounts.get_user!(user.id)
     end
 
@@ -65,34 +69,43 @@ defmodule Docdog.AccountsTest do
       assert %Ecto.Changeset{} = Accounts.change_user(user)
     end
 
-    test "find_or_create/1 returns existed user when found by github uid", %{user: user} do
+    test "find_or_create/1 returns existed user when found by github uid", %{
+      user: user
+    } do
       {:ok, found_user} =
-        Accounts.find_or_create(%Ueberauth.Auth{uid: 1234567})
+        Accounts.find_or_create(%Ueberauth.Auth{uid: 1_234_567})
 
       assert user == found_user
     end
 
-    test "find_or_create/1 returns just created user with usesrname from name", %{
-      user: existed_user
-    } do
-      {:ok, new_user} = Accounts.find_or_create(%Ueberauth.Auth{info: @create_attrs_from_github})
+    test "find_or_create/1 returns just created user with usesrname from name",
+         %{
+           user: existed_user
+         } do
+      {:ok, new_user} =
+        Accounts.find_or_create(%Ueberauth.Auth{info: @create_attrs_from_github})
+
       refute existed_user == new_user
       assert new_user.username == "Petr Petroff"
     end
 
-    test "find_or_create/1 returns just created user when info with empty name", %{
-      user: existed_user
-    } do
+    test "find_or_create/1 returns just created user when info with empty name",
+         %{
+           user: existed_user
+         } do
       params_without_name = %{@create_attrs_from_github | name: nil}
 
-      {:ok, new_user} = Accounts.find_or_create(%Ueberauth.Auth{info: params_without_name})
+      {:ok, new_user} =
+        Accounts.find_or_create(%Ueberauth.Auth{info: params_without_name})
+
       refute existed_user == new_user
       assert new_user.username == "Petr Petrov"
     end
 
-    test "find_or_create/1 returns just created user when no any names in info", %{
-      user: existed_user
-    } do
+    test "find_or_create/1 returns just created user when no any names in info",
+         %{
+           user: existed_user
+         } do
       params_without_any_names = %{
         @create_attrs_from_github
         | name: nil,
@@ -100,7 +113,9 @@ defmodule Docdog.AccountsTest do
           last_name: nil
       }
 
-      {:ok, new_user} = Accounts.find_or_create(%Ueberauth.Auth{info: params_without_any_names})
+      {:ok, new_user} =
+        Accounts.find_or_create(%Ueberauth.Auth{info: params_without_any_names})
+
       refute existed_user == new_user
       assert new_user.username == "petr_petrov"
     end

--- a/test/docdog/editor/editor_test.exs
+++ b/test/docdog/editor/editor_test.exs
@@ -10,13 +10,23 @@ defmodule Docdog.EditorTest do
     alias Docdog.Editor.Project
 
     @valid_attrs string_params_for(:project)
-    @update_attrs %{"name" => "Phoenix Documentation", "description" => "New description"}
+    @update_attrs %{
+      "name" => "Phoenix Documentation",
+      "description" => "New description"
+    }
     @invalid_attrs %{"name" => nil}
 
     setup do
       user = insert(:user)
       document = insert(:document, user: user)
-      project = insert(:project, user: user, documents: [document], invite_code: "966f1fa5-eada-40b6-aad3-735032e12740")
+
+      project =
+        insert(
+          :project,
+          user: user,
+          documents: [document],
+          invite_code: "966f1fa5-eada-40b6-aad3-735032e12740"
+        )
 
       {:ok, user: user, project: project}
     end
@@ -25,50 +35,81 @@ defmodule Docdog.EditorTest do
       assert Editor.list_projects() == [project]
     end
 
-    test "full_list_projects/0 returns all projects with completed percentages", %{user: user} do
+    test "full_list_projects/0 returns all projects with completed percentages",
+         %{user: user} do
       processed_line = build(:processed_line)
       unprocessed_line = build(:unprocessed_line)
-      document = build(:document, user: user, lines: [processed_line, unprocessed_line])
-      project = insert(:project, user: user, documents: [document], invite_code: "966f1fa5-eada-40b6-aad3-735032e12741")
+
+      document =
+        build(:document, user: user, lines: [processed_line, unprocessed_line])
+
+      project =
+        insert(
+          :project,
+          user: user,
+          documents: [document],
+          invite_code: "966f1fa5-eada-40b6-aad3-735032e12741"
+        )
 
       project_with_percentage =
-        Enum.find(Editor.full_list_projects(user), fn p -> p.id == project.id end)
+        Enum.find(Editor.full_list_projects(user), fn p ->
+          p.id == project.id
+        end)
 
-      assert Decimal.to_float(project_with_percentage.completed_percentage) == 50.0
+      assert Decimal.to_float(project_with_percentage.completed_percentage) ==
+               50.0
     end
 
     test "get_project!/1 returns the project with given id", %{project: project} do
       assert Editor.get_project!(project.id) == project
     end
 
-    test "get_project_by_invite_code!/1 returns the project with given id", %{project: project} do
-      assert Editor.get_project_by_invite_code!("966f1fa5-eada-40b6-aad3-735032e12740") == project
+    test "get_project_by_invite_code!/1 returns the project with given id", %{
+      project: project
+    } do
+      assert Editor.get_project_by_invite_code!(
+               "966f1fa5-eada-40b6-aad3-735032e12740"
+             ) == project
     end
 
     test "create_project/2 with valid data creates a project", %{user: user} do
-      assert {:ok, %Project{} = project} = Editor.create_project(user, @valid_attrs)
+      assert {:ok, %Project{} = project} =
+               Editor.create_project(user, @valid_attrs)
+
       assert project.name == "Elixir Documentation"
     end
 
-    test "create_project/2 with invalid data returns error changeset", %{user: user} do
-      assert {:error, %Ecto.Changeset{}} = Editor.create_project(user, @invalid_attrs)
+    test "create_project/2 with invalid data returns error changeset", %{
+      user: user
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               Editor.create_project(user, @invalid_attrs)
     end
 
-    test "update_project/2 with valid data updates the project", %{project: project} do
+    test "update_project/2 with valid data updates the project", %{
+      project: project
+    } do
       assert {:ok, project} = Editor.update_project(project, @update_attrs)
       assert %Project{} = project
       assert project.name == "Phoenix Documentation"
       assert project.description == "New description"
     end
 
-    test "update_project/2 with invalid data returns error changeset", %{project: project} do
-      assert {:error, %Ecto.Changeset{}} = Editor.update_project(project, @invalid_attrs)
+    test "update_project/2 with invalid data returns error changeset", %{
+      project: project
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               Editor.update_project(project, @invalid_attrs)
+
       assert project == Editor.get_project!(project.id)
     end
 
     test "delete_project/1 deletes the project", %{project: project} do
       assert {:ok, %Project{}} = Editor.delete_project(project)
-      assert_raise Ecto.NoResultsError, fn -> Editor.get_project!(project.id) end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Editor.get_project!(project.id)
+      end
     end
 
     test "change_project/1 returns a project changeset", %{project: project} do
@@ -85,7 +126,14 @@ defmodule Docdog.EditorTest do
 
     setup do
       user = insert(:user)
-      project = insert(:project, user: user, invite_code: "02e12272-c477-477f-a9c4-f4e898e111f0")
+
+      project =
+        insert(
+          :project,
+          user: user,
+          invite_code: "02e12272-c477-477f-a9c4-f4e898e111f0"
+        )
+
       document = insert(:document, user: user, project: project, lines: [])
 
       {:ok, user: user, project: project, document: document}
@@ -95,19 +143,27 @@ defmodule Docdog.EditorTest do
       assert Editor.list_documents() == [document]
     end
 
-    test "list_documents_for_project/1 returns all documents for given project", %{
-      project: project,
-      document: document
-    } do
+    test "list_documents_for_project/1 returns all documents for given project",
+         %{
+           project: project,
+           document: document
+         } do
       assert Editor.list_documents_for_project(project.id) == [document]
     end
 
-    test "get_document!/1 returns the document with given id", %{document: document} do
+    test "get_document!/1 returns the document with given id", %{
+      document: document
+    } do
       assert Editor.get_document!(document.id) == document
     end
 
-    test "create_document/3 with valid data creates a document", %{project: project, user: user} do
-      assert {:ok, %Document{} = document} = Editor.create_document(project, user, @valid_attrs)
+    test "create_document/3 with valid data creates a document", %{
+      project: project,
+      user: user
+    } do
+      assert {:ok, %Document{} = document} =
+               Editor.create_document(project, user, @valid_attrs)
+
       assert document.name == "Introduction"
 
       first_line = hd(document.lines)
@@ -118,23 +174,33 @@ defmodule Docdog.EditorTest do
       project: project,
       user: user
     } do
-      assert {:error, %Ecto.Changeset{}} = Editor.create_document(project, user, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} =
+               Editor.create_document(project, user, @invalid_attrs)
     end
 
-    test "update_document/2 with valid data updates the document", %{document: document} do
+    test "update_document/2 with valid data updates the document", %{
+      document: document
+    } do
       assert {:ok, document} = Editor.update_document(document, @update_attrs)
       assert %Document{} = document
       assert document.name == "Getting Started"
     end
 
-    test "update_document/2 with invalid data returns error changeset", %{document: document} do
-      assert {:error, %Ecto.Changeset{}} = Editor.update_document(document, @invalid_attrs)
+    test "update_document/2 with invalid data returns error changeset", %{
+      document: document
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               Editor.update_document(document, @invalid_attrs)
+
       assert document == Editor.get_document!(document.id)
     end
 
     test "delete_document/1 deletes the document", %{document: document} do
       assert {:ok, %Document{}} = Editor.delete_document(document)
-      assert_raise Ecto.NoResultsError, fn -> Editor.get_document!(document.id) end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Editor.get_document!(document.id)
+      end
     end
 
     test "change_document/1 returns a document changeset", %{document: document} do
@@ -149,9 +215,19 @@ defmodule Docdog.EditorTest do
 
     setup do
       user = insert(:user)
-      project = insert(:project, invite_code: "ceefeadc-c73b-4914-9590-b7eef8bb7686")
+
+      project =
+        insert(:project, invite_code: "ceefeadc-c73b-4914-9590-b7eef8bb7686")
+
       document = insert(:document, user: user)
-      line = insert(:processed_line, document: document, user: user, project: project)
+
+      line =
+        insert(
+          :processed_line,
+          document: document,
+          user: user,
+          project: project
+        )
 
       {:ok, user: user, _line: line, document: document}
     end
@@ -167,7 +243,10 @@ defmodule Docdog.EditorTest do
       assert Editor.get_lines_for_document(document) == [line]
     end
 
-    test "update_line/3 with valid data updates the line", %{_line: line, user: user} do
+    test "update_line/3 with valid data updates the line", %{
+      _line: line,
+      user: user
+    } do
       assert {:ok, line} = Editor.update_line(line, user, @update_attrs)
       assert %Line{} = line
       assert line.translated_text == "Эликсир"
@@ -185,7 +264,8 @@ defmodule Docdog.EditorTest do
       snippet = "```elixir\n1+1 # 2\n2+2 # 4\n```"
       encoded_snippet = "```elixir%$%n$%$1+1 # 2%$%n$%$2+2 # 4%$%n$%$```"
 
-      text_with_snippet = "Take a look at the snippet below:\n\n#{snippet}\n\nWow, it works!\n"
+      text_with_snippet =
+        "Take a look at the snippet below:\n\n#{snippet}\n\nWow, it works!\n"
 
       processed_text =
         "Take a look at the snippet below:\n\n#{encoded_snippet}\n\nWow, it works!\n"

--- a/test/docdog_web/controllers/auth_controller_test.exs
+++ b/test/docdog_web/controllers/auth_controller_test.exs
@@ -20,9 +20,11 @@ defmodule DocdogWeb.AuthControllerTest do
   @failure_attrs_from_github %Ueberauth.Failure{}
 
   test "loads sign in page", %{conn: conn} do
-    conn = get conn, "/auth/sign_in"
+    conn = get(conn, "/auth/sign_in")
 
-    assert html_response(conn, 200) =~ "<h1>Built for developers and professional translators</h1>"
+    assert html_response(conn, 200) =~
+             "<h1>Built for developers and professional translators</h1>"
+
     assert html_response(conn, 200) =~ ">Sign in with Github</a>"
   end
 
@@ -34,10 +36,13 @@ defmodule DocdogWeb.AuthControllerTest do
 
     assert redirected_to(conn) == "/workplace/popular"
     assert get_flash(conn, :info) == "Successfully authenticated."
-    assert html_response(conn, 302) =~ "You are being <a href=\"/workplace/popular\">redirected</a>."
+
+    assert html_response(conn, 302) =~
+             "You are being <a href=\"/workplace/popular\">redirected</a>."
   end
 
-  test "when success auth from Github authenticates user and redirect url is /auth/sign_in", %{conn: conn} do
+  test "when success auth from Github authenticates user and redirect url is /auth/sign_in",
+       %{conn: conn} do
     conn =
       conn
       |> init_test_session(%{redirect_url: "/auth/sign_in"})
@@ -45,10 +50,13 @@ defmodule DocdogWeb.AuthControllerTest do
       |> post(auth_path(conn, :callback, :github))
 
     assert redirected_to(conn) == "/workplace/popular"
-    assert html_response(conn, 302) =~ "You are being <a href=\"/workplace/popular\">redirected</a>."
+
+    assert html_response(conn, 302) =~
+             "You are being <a href=\"/workplace/popular\">redirected</a>."
   end
 
-  test "when success auth from Github authenticates user and redirect url is /workplace/projects/123", %{conn: conn} do
+  test "when success auth from Github authenticates user and redirect url is /workplace/projects/123",
+       %{conn: conn} do
     conn =
       conn
       |> init_test_session(%{redirect_url: "/workplace/projects/123"})
@@ -56,17 +64,23 @@ defmodule DocdogWeb.AuthControllerTest do
       |> post(auth_path(conn, :callback, :github))
 
     assert redirected_to(conn) == "/workplace/projects/123"
-    assert html_response(conn, 302) =~ "You are being <a href=\"/workplace/projects/123\">redirected</a>."
+
+    assert html_response(conn, 302) =~
+             "You are being <a href=\"/workplace/projects/123\">redirected</a>."
   end
 
-  test "when success auth from Github, but errors in model redirects to sign in page with error", %{conn: conn} do
+  test "when success auth from Github, but errors in model redirects to sign in page with error",
+       %{conn: conn} do
     conn =
       conn
       |> assign(:ueberauth_auth, @invalid_attrs_from_github)
       |> post(auth_path(conn, :callback, :github))
 
     assert redirected_to(conn) == "/auth/sign_in"
-    assert get_flash(conn, :error) == [email: {"can't be blank", [validation: :required]}]
+
+    assert get_flash(conn, :error) == [
+             email: {"can't be blank", [validation: :required]}
+           ]
   end
 
   test "when failure from Github redirects back with error", %{conn: conn} do
@@ -75,7 +89,10 @@ defmodule DocdogWeb.AuthControllerTest do
     conn = get(conn, auth_path(conn, :callback, :github))
     assert redirected_to(conn) == "/auth/sign_in"
     assert get_flash(conn, :error) == "Failed to authenticate."
-    assert html_response(conn, 302) =~ "You are being <a href=\"/auth/sign_in\">redirected</a>"
+
+    assert html_response(conn, 302) =~
+             "You are being <a href=\"/auth/sign_in\">redirected</a>"
+
     refute get_session(conn, :current_user)
   end
 

--- a/test/docdog_web/controllers/document_controller_test.exs
+++ b/test/docdog_web/controllers/document_controller_test.exs
@@ -21,7 +21,14 @@ defmodule DocdogWeb.DocumentControllerTest do
     line = build(:processed_line)
     public_project = insert(:project, user: user, public: true)
     private_project = insert(:project, user: user, public: false)
-    document = insert(:document, user: user, project: public_project, lines: [line, line])
+
+    document =
+      insert(
+        :document,
+        user: user,
+        project: public_project,
+        lines: [line, line]
+      )
 
     {:ok,
      conn: conn,
@@ -64,7 +71,9 @@ defmodule DocdogWeb.DocumentControllerTest do
       public_project: project,
       document: document
     } do
-      conn = get(conn, project_document_path(conn, :show, project.id, document.id))
+      conn =
+        get(conn, project_document_path(conn, :show, project.id, document.id))
+
       assert html_response(conn, 200) =~ "Show Document"
     end
 
@@ -74,7 +83,10 @@ defmodule DocdogWeb.DocumentControllerTest do
       document: document
     } do
       conn = conn |> put_req_header("accept", "text/markdown")
-      conn = get(conn, project_document_path(conn, :show, project.id, document.id))
+
+      conn =
+        get(conn, project_document_path(conn, :show, project.id, document.id))
+
       assert response_content_type(conn, :md) =~ "text/markdown; charset=utf-8"
       assert response(conn, 200) == "Эликсир - это\n\nЭликсир - это"
     end
@@ -85,7 +97,10 @@ defmodule DocdogWeb.DocumentControllerTest do
       private_project: project
     } do
       document = insert(:document, user: user, project: project)
-      conn = get(conn, project_document_path(conn, :show, project.id, document.id))
+
+      conn =
+        get(conn, project_document_path(conn, :show, project.id, document.id))
+
       assert html_response(conn, 403) =~ "Forbidden"
     end
   end
@@ -106,20 +121,36 @@ defmodule DocdogWeb.DocumentControllerTest do
   end
 
   describe "create document" do
-    test "redirects to show when data is valid", %{conn: conn, public_project: project} do
+    test "redirects to show when data is valid", %{
+      conn: conn,
+      public_project: project
+    } do
       new_conn =
-        post(conn, project_document_path(conn, :create, project.id), document: @create_attrs)
+        post(
+          conn,
+          project_document_path(conn, :create, project.id),
+          document: @create_attrs
+        )
 
       assert %{id: id} = redirected_params(new_conn)
-      assert redirected_to(new_conn) == project_document_path(new_conn, :edit, project.id, id)
+
+      assert redirected_to(new_conn) ==
+               project_document_path(new_conn, :edit, project.id, id)
 
       new_conn = get(conn, project_document_path(conn, :edit, project.id, id))
       assert html_response(new_conn, 200) =~ "Edit Document"
     end
 
-    test "renders errors when data is invalid", %{conn: conn, public_project: project} do
+    test "renders errors when data is invalid", %{
+      conn: conn,
+      public_project: project
+    } do
       conn =
-        post(conn, project_document_path(conn, :create, project.id), document: @invalid_attrs)
+        post(
+          conn,
+          project_document_path(conn, :create, project.id),
+          document: @invalid_attrs
+        )
 
       assert html_response(conn, 200) =~ "New Document"
     end
@@ -129,7 +160,11 @@ defmodule DocdogWeb.DocumentControllerTest do
       private_project: project
     } do
       conn =
-        post(conn, project_document_path(conn, :create, project.id), document: @invalid_attrs)
+        post(
+          conn,
+          project_document_path(conn, :create, project.id),
+          document: @invalid_attrs
+        )
 
       assert html_response(conn, 403) =~ "Forbidden"
     end
@@ -157,16 +192,20 @@ defmodule DocdogWeb.DocumentControllerTest do
   end
 
   describe "delete document" do
-    test "renders unauthorized page for document of private project for admin", %{
-      conn: conn,
-      public_project: project,
-      document: document
-    } do
+    test "renders unauthorized page for document of private project for admin",
+         %{
+           conn: conn,
+           public_project: project,
+           document: document
+         } do
       admin = insert(:user, admin: true)
       conn = assign(conn, :current_user, admin)
 
-      delete_conn = delete(conn, project_document_path(conn, :delete, project.id, document))
-      assert redirected_to(delete_conn) == project_document_path(conn, :index, project.id)
+      delete_conn =
+        delete(conn, project_document_path(conn, :delete, project.id, document))
+
+      assert redirected_to(delete_conn) ==
+               project_document_path(conn, :index, project.id)
 
       assert_error_sent(404, fn ->
         get(conn, project_document_path(conn, :show, project.id, document))
@@ -178,7 +217,9 @@ defmodule DocdogWeb.DocumentControllerTest do
       public_project: project,
       document: document
     } do
-      delete_conn = delete(conn, project_document_path(conn, :delete, project.id, document))
+      delete_conn =
+        delete(conn, project_document_path(conn, :delete, project.id, document))
+
       assert html_response(delete_conn, 403) =~ "Forbidden"
     end
 
@@ -188,7 +229,10 @@ defmodule DocdogWeb.DocumentControllerTest do
       private_project: project
     } do
       document = insert(:document, user: user, project: project)
-      delete_conn = delete(conn, project_document_path(conn, :delete, project.id, document))
+
+      delete_conn =
+        delete(conn, project_document_path(conn, :delete, project.id, document))
+
       assert html_response(delete_conn, 403) =~ "Forbidden"
     end
   end

--- a/test/docdog_web/controllers/line_controller_test.exs
+++ b/test/docdog_web/controllers/line_controller_test.exs
@@ -18,10 +18,16 @@ defmodule DocdogWeb.LineControllerTest do
     processed_line = insert(:processed_line)
     unprocessed_line = insert(:unprocessed_line)
 
-    project = insert(:project, user: user, lines: [processed_line, unprocessed_line])
+    project =
+      insert(:project, user: user, lines: [processed_line, unprocessed_line])
 
     document =
-      insert(:document, user: user, project: project, lines: [processed_line, unprocessed_line])
+      insert(
+        :document,
+        user: user,
+        project: project,
+        lines: [processed_line, unprocessed_line]
+      )
 
     {:ok,
      conn: conn,
@@ -57,7 +63,10 @@ defmodule DocdogWeb.LineControllerTest do
              }
     end
 
-    test "renders unauthorized json for antoher user", %{another_conn: conn, document: document} do
+    test "renders unauthorized json for antoher user", %{
+      another_conn: conn,
+      document: document
+    } do
       conn = get(conn, document_line_path(conn, :index, document.id))
       assert json_response(conn, 403) == %{"error" => "Forbidden"}
     end
@@ -84,8 +93,17 @@ defmodule DocdogWeb.LineControllerTest do
              }
     end
 
-    test "renders errors when data is invalid", %{conn: conn, unprocessed_line: line} do
-      conn = put(conn, line_path(conn, :update, line.id), line: %{"translated_text" => nil})
+    test "renders errors when data is invalid", %{
+      conn: conn,
+      unprocessed_line: line
+    } do
+      conn =
+        put(
+          conn,
+          line_path(conn, :update, line.id),
+          line: %{"translated_text" => nil}
+        )
+
       assert json_response(conn, 400) == %{"status" => "error"}
     end
 
@@ -93,7 +111,13 @@ defmodule DocdogWeb.LineControllerTest do
       another_conn: conn,
       unprocessed_line: line
     } do
-      conn = put(conn, line_path(conn, :update, line.id), line: %{"translated_text" => nil})
+      conn =
+        put(
+          conn,
+          line_path(conn, :update, line.id),
+          line: %{"translated_text" => nil}
+        )
+
       assert json_response(conn, 403) == %{"error" => "Forbidden"}
     end
   end

--- a/test/docdog_web/controllers/popular_controller_test.exs
+++ b/test/docdog_web/controllers/popular_controller_test.exs
@@ -13,7 +13,10 @@ defmodule DocdogWeb.PopularControllerTest do
     private_project = insert(:project, name: "Private Project")
     public_project = insert(:project, name: "Public Project", public: true)
 
-    {:ok, conn: conn, private_project: private_project, public_project: public_project}
+    {:ok,
+     conn: conn,
+     private_project: private_project,
+     public_project: public_project}
   end
 
   describe "index" do

--- a/test/docdog_web/controllers/project_controller_test.exs
+++ b/test/docdog_web/controllers/project_controller_test.exs
@@ -19,13 +19,20 @@ defmodule DocdogWeb.ProjectControllerTest do
       build_conn()
       |> assign(:current_user, another_user)
 
-    project = insert(:project, user: user, name: "Elixir Documentation 1",
-      description: "Official documentation of Elixir language")
+    project =
+      insert(
+        :project,
+        user: user,
+        name: "Elixir Documentation 1",
+        description: "Official documentation of Elixir language"
+      )
 
     project_with_documents =
-      insert(:project, name: "Elixir Documentation 2", user: user) |> with_documents
+      insert(:project, name: "Elixir Documentation 2", user: user)
+      |> with_documents
 
-    _project_of_another_user = insert(:project, name: "Another User Project", user: another_user)
+    _project_of_another_user =
+      insert(:project, name: "Another User Project", user: another_user)
 
     {:ok,
      conn: conn,
@@ -38,7 +45,10 @@ defmodule DocdogWeb.ProjectControllerTest do
     test "lists main user projects", %{conn: conn} do
       conn = get(conn, project_path(conn, :index))
       assert html_response(conn, 200) =~ "Elixir Documentation 1"
-      assert html_response(conn, 200) =~ "Official documentation of Elixir language"
+
+      assert html_response(conn, 200) =~
+               "Official documentation of Elixir language"
+
       assert html_response(conn, 200) =~ "Elixir Documentation 2"
       assert html_response(conn, 200) =~ "No description"
 
@@ -70,12 +80,18 @@ defmodule DocdogWeb.ProjectControllerTest do
   end
 
   describe "edit project" do
-    test "renders form for editing chosen project", %{conn: conn, project: project} do
+    test "renders form for editing chosen project", %{
+      conn: conn,
+      project: project
+    } do
       conn = get(conn, project_path(conn, :edit, project))
       assert html_response(conn, 200) =~ "Edit Project"
     end
 
-    test "renders unauthorized page for another user", %{another_conn: conn, project: project} do
+    test "renders unauthorized page for another user", %{
+      another_conn: conn,
+      project: project
+    } do
       conn = get(conn, project_path(conn, :edit, project))
       assert html_response(conn, 403) =~ "Forbidden"
     end
@@ -83,7 +99,9 @@ defmodule DocdogWeb.ProjectControllerTest do
 
   describe "update project" do
     test "redirects when data is valid", %{conn: conn, project: project} do
-      new_conn = put(conn, project_path(conn, :update, project), project: @update_attrs)
+      new_conn =
+        put(conn, project_path(conn, :update, project), project: @update_attrs)
+
       assert redirected_to(new_conn) == project_path(new_conn, :index)
 
       new_conn = get(conn, project_path(conn, :index))
@@ -91,12 +109,19 @@ defmodule DocdogWeb.ProjectControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, project: project} do
-      conn = put(conn, project_path(conn, :update, project), project: @invalid_attrs)
+      conn =
+        put(conn, project_path(conn, :update, project), project: @invalid_attrs)
+
       assert html_response(conn, 200) =~ "Edit Project"
     end
 
-    test "renders unauthorized page for another user", %{another_conn: conn, project: project} do
-      conn = put(conn, project_path(conn, :update, project), project: @invalid_attrs)
+    test "renders unauthorized page for another user", %{
+      another_conn: conn,
+      project: project
+    } do
+      conn =
+        put(conn, project_path(conn, :update, project), project: @invalid_attrs)
+
       assert html_response(conn, 403) =~ "Forbidden"
     end
   end
@@ -115,7 +140,10 @@ defmodule DocdogWeb.ProjectControllerTest do
       assert redirected_to(conn) == project_path(conn, :index)
     end
 
-    test "renders unauthorized page for another user", %{another_conn: conn, project: project} do
+    test "renders unauthorized page for another user", %{
+      another_conn: conn,
+      project: project
+    } do
       conn = delete(conn, project_path(conn, :delete, project))
       assert html_response(conn, 403) =~ "Forbidden"
     end

--- a/test/docdog_web/controllers/project_invite_controller_test.exs
+++ b/test/docdog_web/controllers/project_invite_controller_test.exs
@@ -11,29 +11,59 @@ defmodule DocdogWeb.ProjectInviteControllerTest do
       build_conn()
       |> assign(:current_user, another_user)
 
-    project = insert(:project, user: user, name: "Elixir Documentation", invite_code: "de4f032e-2fb9-11e8-b467-0ed5f89f718b")
+    project =
+      insert(
+        :project,
+        user: user,
+        name: "Elixir Documentation",
+        invite_code: "de4f032e-2fb9-11e8-b467-0ed5f89f718b"
+      )
 
-    {:ok,
-     another_conn: conn_with_another_user,
-     project: project}
+    {:ok, another_conn: conn_with_another_user, project: project}
   end
 
   describe "index" do
-    test "when user signed in shows invite page with Approve button", %{another_conn: conn} do
-      conn = get(conn, project_invite_path(conn, :show, "de4f032e-2fb9-11e8-b467-0ed5f89f718b"))
+    test "when user signed in shows invite page with Approve button", %{
+      another_conn: conn
+    } do
+      conn =
+        get(
+          conn,
+          project_invite_path(
+            conn,
+            :show,
+            "de4f032e-2fb9-11e8-b467-0ed5f89f718b"
+          )
+        )
 
-      assert html_response(conn, 200) =~ "Invite you to «Elixir Documentation» project"
-      assert html_response(conn, 200) =~ "You were invited to project. Please, accept it."
+      assert html_response(conn, 200) =~
+               "Invite you to «Elixir Documentation» project"
+
+      assert html_response(conn, 200) =~
+               "You were invited to project. Please, accept it."
+
       assert html_response(conn, 200) =~ ">Approve<"
     end
   end
 
   describe "create" do
-    test "adds user to project members and redirects to project docuemnts", %{another_conn: conn, project: project} do
-      conn = post(conn, project_invite_path(conn, :create, %{invite_code: "de4f032e-2fb9-11e8-b467-0ed5f89f718b"}))
+    test "adds user to project members and redirects to project docuemnts", %{
+      another_conn: conn,
+      project: project
+    } do
+      conn =
+        post(
+          conn,
+          project_invite_path(conn, :create, %{
+            invite_code: "de4f032e-2fb9-11e8-b467-0ed5f89f718b"
+          })
+        )
 
-      assert redirected_to(conn) == "/workplace/projects/#{project.id}/documents"
-      assert html_response(conn, 302) =~ "You are being <a href=\"/workplace/projects/#{project.id}/documents\">redirected</a>."
+      assert redirected_to(conn) ==
+               "/workplace/projects/#{project.id}/documents"
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/workplace/projects/#{project.id}/documents\">redirected</a>."
     end
 
     test "when error redirects to invite page", %{conn: _} do

--- a/test/docdog_web/plugs/authorization_required_plug_test.exs
+++ b/test/docdog_web/plugs/authorization_required_plug_test.exs
@@ -18,7 +18,8 @@ defmodule DocdogWeb.AuthorizationRequiredPlugTest do
       {:ok, conn: conn}
     end
 
-    test "redirects to sign in page with proper redirect url and flash message", %{conn: conn} do
+    test "redirects to sign in page with proper redirect url and flash message",
+         %{conn: conn} do
       assert get_session(conn, :redirect_url) == "/workplace/projects"
       assert get_flash(conn, :info) == "Please, sign in to continue."
       assert redirected_to(conn) == "/auth/sign_in"
@@ -41,7 +42,10 @@ defmodule DocdogWeb.AuthorizationRequiredPlugTest do
       {:ok, conn: conn, initial_conn: initial_conn}
     end
 
-    test "current user brings just from assigns when no session", %{conn: conn, initial_conn: initial_conn} do
+    test "current user brings just from assigns when no session", %{
+      conn: conn,
+      initial_conn: initial_conn
+    } do
       assert initial_conn == conn
     end
   end

--- a/test/docdog_web/plugs/current_user_plug_test.exs
+++ b/test/docdog_web/plugs/current_user_plug_test.exs
@@ -39,7 +39,10 @@ defmodule DocdogWeb.CurrentUserPlugTest do
       {:ok, conn: conn, user: user}
     end
 
-    test "current user brings just from assigns when no session", %{conn: conn, user: user} do
+    test "current user brings just from assigns when no session", %{
+      conn: conn,
+      user: user
+    } do
       assert conn.assigns[:current_user] == user
     end
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,7 +18,13 @@ defmodule Docdog.Factory do
   end
 
   def with_documents(project) do
-    insert(:document, project: project, user: build(:user), lines: [build(:processed_line)])
+    insert(
+      :document,
+      project: project,
+      user: build(:user),
+      lines: [build(:processed_line)]
+    )
+
     project
   end
 


### PR DESCRIPTION
Things I have done:

1. Added `.credo.exs` and `.formatter.exs`
2. Added `mix credo --strict` to `travis`
3. Fixed everything by `mix format`
4. Fixed some things manually after that

I understand that this PR is HUUGE, but it is better to enforce coding styles ASAP.
Later, you can configure everything you like/dislike inside `.credo.exs` and `.formatter.exs`.

Closes #38 